### PR TITLE
Add dark mode support with theme toggle

### DIFF
--- a/src/assets/css/Signup.css
+++ b/src/assets/css/Signup.css
@@ -6,7 +6,7 @@
     width: 90%;
     margin: 2rem auto;
     padding: 2rem 2.5rem;
-    background-color: #ffffff;
+    background-color: hsl(var(--card));
     border-radius: 16px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
     transition: transform 0.3s ease;
@@ -21,7 +21,7 @@
     font-weight: 600;
     margin-bottom: 1.5rem;
     text-align: center;
-    color: #1f2937;
+    color: hsl(var(--foreground));
 }
 
 /* Styles généraux du formulaire */
@@ -37,7 +37,9 @@
 .signup-textarea {
     width: 100%;
     padding: 0.75rem 1rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid hsl(var(--border));
+    background-color: hsl(var(--input));
+    color: hsl(var(--foreground));
     border-radius: 8px;
     font-size: 1rem;
     transition: border-color 0.3s ease, box-shadow 0.3s ease;
@@ -60,7 +62,7 @@
 .signup-label {
     font-weight: 500;
     margin-bottom: 0.25rem;
-    color: #374151;
+    color: hsl(var(--foreground));
 }
 
 /* Bouton de soumission */
@@ -88,7 +90,7 @@
     text-align: center;
     margin-top: 1rem;
     font-size: 1rem;
-    color: #1f2937;
+    color: hsl(var(--foreground));
 }
 
 /* Styles pour le logo de validation affiché après inscription */

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,10 +9,13 @@ import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/theme";
 import logo from "../assets/logo/ALFHEIM AI SANS FOND.png";
 
 const Navbar = () => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const { theme, toggleTheme } = useTheme();
 
     // Animation pour l'ouverture/fermeture du menu mobile
     const menuVariants = {
@@ -25,7 +28,7 @@ const Navbar = () => {
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="sticky top-0 z-50 bg-gradient-to-br from-white/70 to-white/90 backdrop-blur-md shadow-md border-b border-gray-200"
+            className="sticky top-0 z-50 bg-gradient-to-br from-white/70 to-white/90 dark:from-gray-800/80 dark:to-gray-700/90 backdrop-blur-md shadow-md border-b border-gray-200 dark:border-gray-700"
         >
             <div className="container mx-auto px-6 py-2 flex items-center justify-between h-16">
                 <div className="flex items-center space-x-3">
@@ -44,13 +47,13 @@ const Navbar = () => {
                 <div className="hidden md:flex space-x-8 items-center">
                     <Link
                         to="/about"
-                        className="text-gray-700 hover:text-blue-600 transition-colors font-medium"
+                        className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium"
                     >
                         En savoir plus
                     </Link>
                     <Link
                         to="/contact"
-                        className="text-gray-700 hover:text-blue-600 transition-colors font-medium"
+                        className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium"
                     >
                         Contact
                     </Link>
@@ -59,11 +62,18 @@ const Navbar = () => {
                             Démo
                         </Button>
                     </Link>
+                    <button
+                        onClick={toggleTheme}
+                        aria-label="Toggle theme"
+                        className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400"
+                    >
+                        {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+                    </button>
                 </div>
                 <div className="md:hidden">
                     <button
                         onClick={() => setIsMenuOpen(!isMenuOpen)}
-                        className="text-gray-700 hover:text-blue-600 focus:outline-none"
+                        className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none"
                     >
                         {isMenuOpen ? (
                             <svg
@@ -104,20 +114,20 @@ const Navbar = () => {
                         animate="open"
                         exit="closed"
                         variants={menuVariants}
-                        className="md:hidden bg-white/95 backdrop-blur-sm border-t border-gray-200"
+                        className="md:hidden bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm border-t border-gray-200 dark:border-gray-700"
                     >
                         <div className="px-6 py-4 flex flex-col space-y-4">
                             <Link
                                 to="/about"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="text-gray-700 hover:text-blue-600 transition-colors font-medium"
+                                className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium"
                             >
                                 En savoir plus
                             </Link>
                             <Link
                                 to="/contact"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="text-gray-700 hover:text-blue-600 transition-colors font-medium"
+                                className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium"
                             >
                                 Contact
                             </Link>
@@ -130,6 +140,16 @@ const Navbar = () => {
                                     Démo
                                 </Button>
                             </Link>
+                            <button
+                                onClick={() => {
+                                    toggleTheme();
+                                    setIsMenuOpen(false);
+                                }}
+                                aria-label="Toggle theme"
+                                className="self-start text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400"
+                            >
+                                {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+                            </button>
                         </div>
                     </motion.div>
                 )}

--- a/src/components/Pages/About.jsx
+++ b/src/components/Pages/About.jsx
@@ -29,7 +29,7 @@ const ExpandableCard = ({ title, intro, children, image, video }) => {
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
-            className="bg-white rounded-2xl shadow-xl p-6 border border-gray-200"
+            className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6 border border-gray-200 dark:border-gray-700"
         >
             {video ? (
                 <video
@@ -49,8 +49,8 @@ const ExpandableCard = ({ title, intro, children, image, video }) => {
                     />
                 )
             )}
-            <h2 className="text-2xl font-semibold mb-2">{title}</h2>
-            <p className="text-gray-600 mb-2">{intro}</p>
+            <h2 className="text-2xl font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h2>
+            <p className="text-gray-600 dark:text-gray-300 mb-2">{intro}</p>
             <button
                 onClick={() => setExpanded(!expanded)}
                 className="flex items-center text-blue-600 hover:underline mb-2"
@@ -65,7 +65,7 @@ const ExpandableCard = ({ title, intro, children, image, video }) => {
                         animate={{ height: "auto", opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
                         transition={{ duration: 0.4 }}
-                        className="mt-4 text-gray-700"
+                        className="mt-4 text-gray-700 dark:text-gray-300"
                     >
                         {children}
                     </motion.div>
@@ -80,7 +80,7 @@ const ExpandableCard = ({ title, intro, children, image, video }) => {
 //
 const About = () => {
     return (
-        <div className="min-h-screen bg-gray-50 text-gray-900 py-10 px-4">
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 py-10 px-4">
             <div className="max-w-6xl mx-auto">
                 {/* En-tête et texte introductif */}
                 <motion.h1
@@ -95,7 +95,7 @@ const About = () => {
                     initial={{ opacity: 0 }}
                     whileInView={{ opacity: 1 }}
                     transition={{ duration: 0.8, delay: 0.3 }}
-                    className="text-lg mb-12 text-center"
+                    className="text-lg mb-12 text-center text-gray-700 dark:text-gray-300"
                 >
                     Alfheim AI révolutionne l'apprentissage des sciences en rendant
                     visibles et interactifs des concepts longtemps restés abstraits. Grâce
@@ -282,7 +282,7 @@ const About = () => {
 
                     {/* 9. Nos valeurs */}
                     <ExpandableCard title="Nos valeurs" intro="">
-                        <p className="text-center mb-6">
+                        <p className="text-center mb-6 text-gray-700 dark:text-gray-300">
                             Chez ALFHEIM AI, au-delà de l'innovation technologique, ce sont nos
                             convictions profondes qui guident chacune de nos actions.
                             <br />
@@ -291,10 +291,10 @@ const About = () => {
                         </p>
                         <div className="space-y-6">
                             <div>
-                                <h3 className="text-xl font-bold mb-1 text-center md:text-left">
+                                <h3 className="text-xl font-bold mb-1 text-center md:text-left text-gray-900 dark:text-gray-100">
                                     Accessibilité
                                 </h3>
-                                <p className="text-center md:text-left">
+                                <p className="text-center md:text-left text-gray-700 dark:text-gray-300">
                                     La connaissance scientifique doit être un droit, pas un
                                     privilège. Nous concevons des outils ouverts, disponibles sur
                                     tous les supports, pour réduire les inégalités d'accès à
@@ -302,40 +302,40 @@ const About = () => {
                                 </p>
                             </div>
                             <div>
-                                <h3 className="text-xl font-bold mb-1 text-center md:text-left">
+                                <h3 className="text-xl font-bold mb-1 text-center md:text-left text-gray-900 dark:text-gray-100">
                                     Pédagogie avant tout
                                 </h3>
-                                <p className="text-center md:text-left">
+                                <p className="text-center md:text-left text-gray-700 dark:text-gray-300">
                                     La technologie n'est pas une fin en soi. Nous plaçons l'efficacité
                                     pédagogique au centre de notre développement, en travaillant en
                                     étroite collaboration avec des enseignants, chercheurs et experts.
                                 </p>
                             </div>
                             <div>
-                                <h3 className="text-xl font-bold mb-1 text-center md:text-left">
+                                <h3 className="text-xl font-bold mb-1 text-center md:text-left text-gray-900 dark:text-gray-100">
                                     Innovation responsable
                                 </h3>
-                                <p className="text-center md:text-left">
+                                <p className="text-center md:text-left text-gray-700 dark:text-gray-300">
                                     Nous utilisons les technologies de pointe (3D, IA, VR) pour
                                     enrichir l'apprentissage, tout en garantissant une utilisation
                                     éthique, sécurisée et respectueuse de l'autonomie de l'élève.
                                 </p>
                             </div>
                             <div>
-                                <h3 className="text-xl font-bold mb-1 text-center md:text-left">
+                                <h3 className="text-xl font-bold mb-1 text-center md:text-left text-gray-900 dark:text-gray-100">
                                     Apprentissage actif
                                 </h3>
-                                <p className="text-center md:text-left">
+                                <p className="text-center md:text-left text-gray-700 dark:text-gray-300">
                                     Comprendre, c'est vivre l'expérience. Nous encourageons
                                     l'expérimentation, l'interaction et l'exploration active, pour
                                     transformer chaque notion théorique en découverte personnelle.
                                 </p>
                             </div>
                             <div>
-                                <h3 className="text-xl font-bold mb-1 text-center md:text-left">
+                                <h3 className="text-xl font-bold mb-1 text-center md:text-left text-gray-900 dark:text-gray-100">
                                     Co-création
                                 </h3>
-                                <p className="text-center md:text-left">
+                                <p className="text-center md:text-left text-gray-700 dark:text-gray-300">
                                     ALFHEIM AI est construit avec les acteurs de l'éducation, pas à
                                     leur place. Nous développons nos contenus et outils en partenariat
                                     avec des établissements, enseignants, chercheurs et laboratoires

--- a/src/components/Pages/Contact.jsx
+++ b/src/components/Pages/Contact.jsx
@@ -22,7 +22,7 @@ const cardVariants = {
 
 const Contact = () => {
     return (
-        <div className="min-h-screen bg-white text-gray-900 py-16">
+        <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 py-16">
             <div className="container mx-auto px-4">
                 {/* Titre animé */}
                 <motion.h1
@@ -38,7 +38,7 @@ const Contact = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
                     {/* Capsule Contact */}
                     <motion.div
-                        className="bg-gray-50 p-8 border border-gray-200 shadow-sm transition-colors"
+                        className="bg-gray-50 dark:bg-gray-800 p-8 border border-gray-200 dark:border-gray-700 shadow-sm transition-colors"
                         variants={cardVariants}
                         whileHover="hover"
                         initial={{ opacity: 0, x: -50, borderRadius: "0.5rem" }}  // coins ~8px
@@ -46,17 +46,17 @@ const Contact = () => {
                         transition={{ duration: 0.3 }}
                     >
                         <h2 className="text-3xl font-bold mb-4">Une question ou une demande ?</h2>
-                        <p className="text-lg mb-4">
+                        <p className="text-lg mb-4 text-gray-700 dark:text-gray-300">
                             Pour une démonstration, une idée à partager ou toute collaboration, notre équipe est disponible 24/7.
                         </p>
-                        <p className="text-lg">
+                        <p className="text-lg text-gray-700 dark:text-gray-300">
                             Remplissez le formulaire ou contactez-nous directement par email.
                         </p>
                     </motion.div>
 
                     {/* Capsule Partenariat / Investissement */}
                     <motion.div
-                        className="bg-gray-50 p-8 border border-gray-200 shadow-sm transition-colors"
+                        className="bg-gray-50 dark:bg-gray-800 p-8 border border-gray-200 dark:border-gray-700 shadow-sm transition-colors"
                         variants={cardVariants}
                         whileHover="hover"
                         initial={{ opacity: 0, x: 50, borderRadius: "0.5rem" }}
@@ -64,10 +64,10 @@ const Contact = () => {
                         transition={{ duration: 0.3 }}
                     >
                         <h2 className="text-3xl font-bold mb-4">Partenariat / Investissement</h2>
-                        <p className="text-lg mb-4">
+                        <p className="text-lg mb-4 text-gray-700 dark:text-gray-300">
                             Soutenez la révolution de l'apprentissage scientifique en devenant partenaire ou investisseur.
                         </p>
-                        <p className="text-lg">
+                        <p className="text-lg text-gray-700 dark:text-gray-300">
                             Contactez-nous directement par mail à :{" "}
                             <a
                                 href="mailto:contact@alfheim-ai.com"
@@ -81,7 +81,7 @@ const Contact = () => {
 
                 {/* Coordonnées et réseaux sociaux */}
                 <motion.div
-                    className="mt-16 bg-gray-50 p-8 border border-gray-200 shadow-sm text-center transition-colors"
+                    className="mt-16 bg-gray-50 dark:bg-gray-800 p-8 border border-gray-200 dark:border-gray-700 shadow-sm text-center transition-colors"
                     variants={cardVariants}
                     whileHover="hover"
                     initial={{ opacity: 0, y: 20, borderRadius: "0.5rem" }}
@@ -89,9 +89,9 @@ const Contact = () => {
                     transition={{ duration: 0.3 }}
                 >
                     <h3 className="text-2xl font-bold mb-4">Nos Coordonnées</h3>
-                    <p className="text-lg mb-1">contact@alfheim-ai.com</p>
-                    <p className="text-lg mb-1">b.araujo@alfheim-ai.com</p>
-                    <p className="text-lg mb-4">+33 7 69 13 60 50</p>
+                    <p className="text-lg mb-1 text-gray-700 dark:text-gray-300">contact@alfheim-ai.com</p>
+                    <p className="text-lg mb-1 text-gray-700 dark:text-gray-300">b.araujo@alfheim-ai.com</p>
+                    <p className="text-lg mb-4 text-gray-700 dark:text-gray-300">+33 7 69 13 60 50</p>
                     {/* Icônes réseaux sociaux */}
                     <div className="flex justify-center space-x-6">
                         <a

--- a/src/components/Pages/Home.jsx
+++ b/src/components/Pages/Home.jsx
@@ -56,7 +56,7 @@ const Home = () => {
                     className="space-y-6"
                 >
                     <h1 className="text-5xl font-bold leading-tight">ALFHEIM AI</h1>
-                    <p className="text-xl text-gray-700">
+                    <p className="text-xl text-gray-700 dark:text-gray-300">
                         Transformez et simplifiez l’apprentissage des sciences grâce à une plateforme immersive, interactive et personnalisée, pensée pour les établissements, professeurs, étudiants et passionnés.
                     </p>
                     <div className="space-x-4">
@@ -109,33 +109,33 @@ const Home = () => {
                     >
                         <h2 className="text-4xl font-bold">Aperçu des fonctionnalités</h2>
                         <div className="grid md:grid-cols-3 gap-8">
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">
                                     Modèles 3D interactifs & Animations dynamiques
                                 </h3>
-                                <p className="text-gray-700">
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Visualisez et explorez les concepts scientifiques en profondeur.
                                 </p>
                             </div>
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">
                                     Travaux pratiques immersifs (Mode VR inclus)
                                 </h3>
-                                <p className="text-gray-700">
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Mettez en pratique vos connaissances en ligne ou en VR.
                                 </p>
                             </div>
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">
                                     IA pédagogique adaptative (Recherche intelligente & Analyse)
                                 </h3>
-                                <p className="text-gray-700">
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Un accompagnement personnalisé, des réponses instantanées.
                                 </p>
                             </div>
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">Suivi des progrès</h3>
-                                <p className="text-gray-700">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Suivi des progrès</h3>
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Analysez votre évolution et optimisez vos acquis.
                                 </p>
                             </div>
@@ -158,21 +158,21 @@ const Home = () => {
                     >
                         <h2 className="text-4xl font-bold">Nos avantages</h2>
                         <div className="grid md:grid-cols-3 gap-8">
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">Apprentissage immersif</h3>
-                                <p className="text-gray-700">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Apprentissage immersif</h3>
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Plongez dans un univers 3D interactif pour une compréhension concrète des concepts scientifiques.
                                 </p>
                             </div>
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">IA adaptative</h3>
-                                <p className="text-gray-700">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">IA adaptative</h3>
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Un accompagnement personnalisé qui s'ajuste à vos besoins et à votre rythme d'apprentissage.
                                 </p>
                             </div>
-                            <div className="p-6 rounded-xl bg-white/80 backdrop-blur">
-                                <h3 className="text-xl font-semibold mb-4 text-gray-900">Contenu de qualité</h3>
-                                <p className="text-gray-700">
+                            <div className="p-6 rounded-xl bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                                <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Contenu de qualité</h3>
+                                <p className="text-gray-700 dark:text-gray-300">
                                     Des ressources fiables, conçues en collaboration avec des enseignants, chercheurs et laboratoires, régulièrement mises à jour pour assurer un apprentissage de qualité.
                                 </p>
                             </div>

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -170,7 +170,7 @@ const Signup = () => {
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value)}
                     required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 />
                 {/* Champ Nom */}
                 <input
@@ -179,7 +179,7 @@ const Signup = () => {
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value)}
                     required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 />
                 {/* Champ Email */}
                 <input
@@ -188,7 +188,7 @@ const Signup = () => {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 />
                 {/* Champ Établissement */}
                 <input
@@ -196,7 +196,7 @@ const Signup = () => {
                     placeholder="Établissement ou Organisation"
                     value={institution}
                     onChange={(e) => setInstitution(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 />
                 {/* Champ Domaine d’études ou d’activité */}
                 <input
@@ -204,14 +204,14 @@ const Signup = () => {
                     placeholder="Domaine d’études ou d’activité"
                     value={studyField}
                     onChange={(e) => setStudyField(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 />
                 {/* Sélecteur Statut */}
                 <select
                     value={status}
                     onChange={(e) => setStatus(e.target.value)}
                     required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 >
                     <option value="" disabled>
                         Statut
@@ -276,7 +276,7 @@ const Signup = () => {
                             placeholder="Veuillez préciser"
                             value={otherMotivation}
                             onChange={(e) => setOtherMotivation(e.target.value)}
-                            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 mt-2"
+                            className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 mt-2"
                         />
                     )}
                 </div>
@@ -315,8 +315,8 @@ const Signup = () => {
                     onChange={(e) => setCurrentLevel(e.target.value)}
                     required={status === "Étudiant(e)"}
                     disabled={status !== "Étudiant(e)"}
-                    className={`w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 ${
-                        status !== "Étudiant(e)" ? "bg-gray-100" : ""
+                    className={`w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+                        status !== "Étudiant(e)" ? "bg-gray-100 dark:bg-gray-700/50" : ""
                     }`}
                 >
                     <option value="" disabled>
@@ -402,7 +402,7 @@ const Signup = () => {
                     placeholder="Avez-vous une suggestion ou une attente spécifique vis-à-vis d’Alfheim IA ?"
                     value={suggestions}
                     onChange={(e) => setSuggestions(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                     rows="4"
                 />
                 {/* Bouton de soumission */}

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,29 @@
     --ring: 210 90% 56%;
     --radius: 1rem;
   }
+
+  .dark {
+    --background: 210 10% 12%;
+    --foreground: 210 20% 95%;
+    --card: 210 10% 20%;
+    --card-foreground: 210 20% 95%;
+    --popover: 210 10% 20%;
+    --popover-foreground: 210 20% 95%;
+    --primary: 210 90% 56%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 210 15% 30%;
+    --secondary-foreground: 210 20% 95%;
+    --muted: 210 20% 25%;
+    --muted-foreground: 210 10% 70%;
+    --accent: 210 15% 35%;
+    --accent-foreground: 210 20% 95%;
+    --destructive: 0 70% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 210 20% 30%;
+    --input: 210 20% 30%;
+    --ring: 210 90% 60%;
+    --radius: 1rem;
+  }
 }
 
 @layer base {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { ThemeProvider } from "./theme";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
         <BrowserRouter>
-            <App />
+            <ThemeProvider>
+                <App />
+            </ThemeProvider>
         </BrowserRouter>
     </React.StrictMode>
 );

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext({ theme: 'light', toggleTheme: () => {} });
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored || (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    if (initial === 'dark') {
+      document.documentElement.classList.add('dark');
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    if (newTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- create ThemeProvider with useTheme hook
- define dark mode color variables
- add theme toggle button in Navbar and menu
- apply dark mode styles across pages
- update signup styles to use CSS variables

## Testing
- `npm install`
- `npm run build` *(fails: `firebase: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68418ae24d308333b26102e5021f4e55