### PR TITLE
Fix Hero3D missing component

### DIFF
--- a/src/components/Hero3D.jsx
+++ b/src/components/Hero3D.jsx
@@ -11,7 +11,7 @@ import { useGLTF, Html, OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 
 // Composant pour un point d'intérêt interactif
-/*function PointOfInterest({ position, label }) {
+function PointOfInterest({ position, label }) {
     const [open, setOpen] = useState(false);
     return (
         <mesh
@@ -41,7 +41,7 @@ import * as THREE from "three";
             )}
         </mesh>
     );
-}*/
+}
 
 export default function Hero3D() {
     const groupRef = useRef();


### PR DESCRIPTION
## Summary
- restore `PointOfInterest` component used in `Hero3D`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d721231483269c5b4f637b42e149